### PR TITLE
Settings Page Appearance

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -1,40 +1,40 @@
 <?php
 
 class Plugin_Conflicts_Admin {
-    
-    	/**
+
+	/**
 	 * Instance of this class.
 	 *
 	 * @since    1.0.0
 	 * @var      object
 	 */
 	private static $instance = null;
-        
-        /**
+
+	/**
 	 * Slug of the settings page
 	 *
 	 * @since    1.0.0
 	 * @var      string
 	 */
 	public $plugin_screen_hook_suffix = null;
-        
-        /**
+
+	/**
 	 *
 	 * @var Plugin_Conflicts
 	 */
 	protected $plugin;
-        
-        public function __construct(){
-                $this->plugin = Plugin_Conflicts::get_instance();
-                
-                // settings page
-		add_action( 'admin_init', array($this, 'settings_init') );
-                
-                // add menu items
-		add_action( 'admin_menu', array($this, 'add_menu_page') );
-        }
-        
-        /**
+
+	public function __construct() {
+		$this->plugin = Plugin_Conflicts::get_instance();
+
+		// settings page
+		add_action( 'admin_init', array( $this, 'settings_init' ) );
+
+		// add menu items
+		add_action( 'admin_menu', array( $this, 'add_menu_page' ) );
+	}
+
+	/**
 	 * Return an instance of this class.
 	 *
 	 * @since     1.0.0
@@ -49,100 +49,109 @@ class Plugin_Conflicts_Admin {
 
 		return self::$instance;
 	}
-        
-        /**
+
+	/**
 	 * register admin pages
 	 *
 	 * @since    1.0.0
 	 */
 	public function add_menu_page() {
 
-                $this->plugin_screen_hook_suffix = add_management_page( __('Debug Plugin conflicts', 'plugin-conflicts'), __('Plugin Conflicts', 'plugin-conflicts'), 'manage_options', PC_SLUG, array($this, 'render_menu_page' ) );
-            
+		$this->plugin_screen_hook_suffix = add_management_page( __( 'Debug Plugin conflicts', 'plugin-conflicts' ), __( 'Plugin Conflicts', 'plugin-conflicts' ), 'manage_options', PC_SLUG, array(
+			$this,
+			'render_menu_page'
+		) );
+
 	}
-        
-        /**
-         * render plugin page
-         * 
-         * @since 1.0.0
-         */
-        public function render_menu_page(){
-                include PC_BASE_PATH . 'admin/views/page.php';
-        }
-        
-        
-        /**
+
+	/**
+	 * render plugin page
+	 *
+	 * @since 1.0.0
+	 */
+	public function render_menu_page() {
+		include PC_BASE_PATH . 'admin/views/page.php';
+	}
+
+
+	/**
 	 * initialize settings
 	 *
 	 * @since 1.0.0
 	 */
-        public function settings_init(){
+	public function settings_init() {
 
-                // get settings page hook
-                $hook = $this->plugin_screen_hook_suffix;
+		// get settings page hook
+		$hook = $this->plugin_screen_hook_suffix;
 
-                // register settings
-                register_setting( PC_SLUG, PC_SLUG, array($this, 'sanitize_settings') );
+		// register settings
+		register_setting( PC_SLUG, PC_SLUG, array( $this, 'sanitize_settings' ) );
 
-                // general settings section
-                add_settings_section(
-                        'plugin_conflicts_setting_section',
-                        __( 'Settings', 'plugin-conflicts' ),
-                        array($this, 'render_settings_section_callback'),
-                        $hook
-                );
-                // choose plugins
-                add_settings_field(
-                        'plugins',
-                        __( 'Choose plugins', 'plugin-conflicts' ),
-                        array($this, 'render_settings_plugins'),
-                        $hook,
-                        'plugin_conflicts_setting_section'
-                );
-        }
-        
-        /**
-         * sanitize settings
-         * basically remove them when reset button was clicked
-         * 
-         * @since 1.0.0
-         * @param arr $settings unsanitized settings
-         * @return arr $settings sanitized settings
-         */
-        public function sanitize_settings( $settings ){
-            
-            if( isset( $settings['reset'] ) && isset( $settings['plugins'] ) ){
-                unset( $settings['plugins'] );
-                unset( $settings['reset'] );
-            }
-            
-            return $settings;
-        }
-        
-        /**
+		// general settings section
+		add_settings_section(
+			'plugin_conflicts_setting_section',
+			__( 'Reset Plugins', 'plugin-conflicts' ),
+			array( $this, 'render_settings_section_callback' ),
+			$hook
+		);
+
+		// choose plugins
+		add_settings_section(
+			'plugins',
+			__( 'Choose Plugins', 'plugin-conflicts' ),
+			array( $this, 'render_settings_plugins' ),
+			$hook
+		);
+
+	}
+
+	/**
+	 * sanitize settings
+	 * basically remove them when reset button was clicked
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param arr $settings unsanitized settings
+	 *
+	 * @return arr $settings sanitized settings
+	 */
+	public function sanitize_settings( $settings ) {
+
+		if ( isset( $settings['reset'] ) && isset( $settings['plugins'] ) ) {
+			unset( $settings['plugins'] );
+			unset( $settings['reset'] );
+		}
+
+		return $settings;
+	}
+
+	/**
 	 * render settings section
 	 *
 	 * @since 1.0.0
 	 */
-        public function render_settings_section_callback(){
-                // for whatever purpose there might come
-                echo '<input type="submit" class="button" name="plugin-conflicts[reset]" value="'. __( 'reset settings to current plugin status', 'plugin-conflicts' ) .'"/>';
-        }
-        
-        /**
+	public function render_settings_section_callback() {
+		// for whatever purpose there might come
+		echo '<p class="description">';
+		_e( 'Click here to reset your reset your plugins to the default settings', 'plugins-conflicts' );
+		echo '</p>';
+		echo '<input type="submit" class="button" name="plugin-conflicts[reset]" value="' . __( 'Reset Plugins', 'plugin-conflicts' ) . '"/>';
+	}
+
+	/**
 	 * render setting to select plugins
 	 *
 	 * @since 1.0.0
 	 */
-        public function render_settings_plugins(){
-                
-                $options = $this->plugin->options();
-                $plugins = isset($options['plugins']) ? $options['plugins'] : array();
-                
-                $all_plugins = get_plugins();
-                
-                // load the template
-                include PC_BASE_PATH . 'admin/views/settings-plugins.php';
-        }
-    
+	public function render_settings_plugins() {
+
+		$options = $this->plugin->options();
+		$plugins = isset( $options['plugins'] ) ? $options['plugins'] : array();
+
+		$all_plugins = get_plugins();
+
+		// load the template
+		include PC_BASE_PATH . 'admin/views/settings-plugins.php';
+	}
+
 }

--- a/admin/views/page.php
+++ b/admin/views/page.php
@@ -1,59 +1,77 @@
-<?php screen_icon(); ?>
-<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
-<?php settings_errors(); ?>
-<h3><?php _e( 'Toggle debug mode', 'plugin-conflicts' ); ?></h3>
-<button id="plugin-conflicts-enable" class="button" type="button" ><?php _e( 'start debug mode', 'plugin-conflicts' ); ?></button>
-<p class="description"><?php _e( 'Debug mode is enabled with the browser, so you are the only one in it. You can either switch it off here or it will expire automatically when you close the session.', 'plugin-conflicts' ); ?></p>
-<form method="post" action="options.php"><?php
-        settings_fields( PC_SLUG );
-        do_settings_sections( $this->plugin_screen_hook_suffix );
-        submit_button( __( 'Save', 'plugin-conflicts' ) );
-    ?>
-</form>
-<script>
-var pc_cookie_name = 'plugin_conflicts_enabled';
-function pc_button_text(){
-    var button = jQuery('#plugin-conflicts-enable');
-    if( pc_read_cookie( pc_cookie_name ) ){
-        button.text( '<?php _e( 'debug mode running', 'plugin-conflicts' ); ?>' );
-    } else {
-        button.text( '<?php _e( 'start debug mode', 'plugin-conflicts' ); ?>' );
-    }
-}
-pc_button_text();
+<div class="wrap">
+	<?php screen_icon(); ?>
+	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
+	<?php settings_errors(); ?>
+	<div id="plugin-conflicts-status" class="notice notice-info">
+		<p><?php _e( 'Debug mode is not running', 'plugin-conflicts' ); ?></p></div>
 
-jQuery('#plugin-conflicts-enable').click(function(){
-    pc_toggle_enabled();
-    pc_button_text();
-});
-function pc_toggle_enabled(){
-    if( pc_read_cookie( pc_cookie_name ) ){
-        pc_erase_cookie( pc_cookie_name );
-    } else {
-        pc_create_cookie( pc_cookie_name, true, false );
-    }
-}
-// source: http://www.quirksmode.org/js/cookies.html
-function pc_create_cookie(name,value,days) {
-	if (days) {
-		var date = new Date();
-		date.setTime(date.getTime()+(days*24*60*60*1000));
-		var expires = "; expires="+date.toGMTString();
+	<h2><?php _e( 'Toggle debug mode', 'plugin-conflicts' ); ?></h2>
+	<p class="description"><?php _e( 'Debug mode is only enabled within this browser session. Other users will not be effected by these settings. You can either switch it off here or it will expire automatically when you close the session.', 'plugin-conflicts' ); ?></p>
+	<button id="plugin-conflicts-enable" class="button-primary"
+	        type="button"><?php _e( 'Start Debug Mode', 'plugin-conflicts' ); ?></button>
+	<form method="post" action="options.php">
+		<?php
+		do_settings_sections( $this->plugin_screen_hook_suffix );
+		settings_fields( PC_SLUG );
+		submit_button( __( 'Save', 'plugin-conflicts' ) );
+		?>
+	</form>
+</div>
+<script>
+	var pc_cookie_name = 'plugin_conflicts_enabled';
+	function pc_button_text() {
+		var button = jQuery('#plugin-conflicts-enable');
+		var notice = jQuery('#plugin-conflicts-status');
+
+		notice.toggleClass('notice-info notice-warning');
+
+		if (pc_read_cookie(pc_cookie_name)) {
+			button.text('<?php _e( 'Stop Debug Mode', 'plugin-conflicts' ); ?>');
+			notice.children('p').text('<?php _e( 'Debug mode is running', 'plugin-conflicts' ); ?>');
+		} else {
+			button.text('<?php _e( 'Start Debug Mode', 'plugin-conflicts' ); ?>');
+			notice.children('p').text('<?php _e( 'Debug mode is not running', 'plugin-conflicts' ); ?>');
+		}
 	}
-	else var expires = "";
-	document.cookie = name+"="+value+expires+"; path=/";
-}
-function pc_read_cookie(name) {
-	var nameEQ = name + "=";
-	var ca = document.cookie.split(';');
-	for(var i=0;i < ca.length;i++) {
-		var c = ca[i];
-		while (c.charAt(0)==' ') c = c.substring(1,c.length);
-		if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+	pc_button_text();
+
+	jQuery('#plugin-conflicts-enable').click(function () {
+		pc_toggle_enabled();
+		pc_button_text();
+	});
+	function pc_toggle_enabled() {
+		if (pc_read_cookie(pc_cookie_name)) {
+			pc_erase_cookie(pc_cookie_name);
+		} else {
+			pc_create_cookie(pc_cookie_name, true, false);
+		}
 	}
-	return null;
-}
-function pc_erase_cookie(name) {
-	pc_create_cookie(name,"",-1);
-}
+
+	// toggle row class
+	jQuery('input[name^="plugin-conflicts[plugins]"]').on('change', function () {
+		jQuery(this).parents('tr').toggleClass('active inactive');
+	});
+	// source: http://www.quirksmode.org/js/cookies.html
+	function pc_create_cookie(name, value, days) {
+		if (days) {
+			var date = new Date();
+			date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000));
+			var expires = "; expires=" + date.toGMTString();
+		}
+		else var expires = "";
+		document.cookie = name + "=" + value + expires + "; path=/";
+	}
+	function pc_read_cookie(name) {
+		var nameEQ = name + "=";
+		var ca = document.cookie.split(';');
+		for (var i = 0; i < ca.length; i++) {
+			var c = ca[i];
+			while (c.charAt(0) == ' ') c = c.substring(1, c.length);
+			if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length, c.length);
+		}
+		return null;
+	}
+	function pc_erase_cookie(name) {
+		pc_create_cookie(name, "", -1);
+	}
 </script>

--- a/admin/views/settings-plugins.php
+++ b/admin/views/settings-plugins.php
@@ -1,29 +1,51 @@
-<?php if ( is_array( $all_plugins ) && count( $all_plugins ) ) : 
-?><table>
-    <tbody>
-    <th><?php _e( 'plugin', 'plugin-conflicts' ); ?></th>
-    <th><?php _e( 'active', 'plugin-conflicts' ); ?></th>
-    <?php /* <th><?php _e( 'switching', 'plugin-conflicts' ); ?></th>*/?>
-    <th><?php _e( 'inactive', 'plugin-conflicts' ); ?></th>
-    </tbody>
-    <?php
-foreach ( $all_plugins as $_plugin_path => $_plugin ) :
-    // load status
-    if ( isset( $plugins[ $_plugin_path ] ) ) {
-        $status = $plugins[ $_plugin_path ];
-    } else {
-        if(is_plugin_active( $_plugin_path )){
-            $status = 'active';
-        } else {
-            $status = 'inactive';
-        }
-    }
-    ?><tr>
-        <td><?php echo $_plugin['Name']; ?></td>
-        <td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]" value="active" <?php checked( 'active', $status ); ?>></td>
-        <?php /* <td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]" value="switching" <?php checked( 'switching', $status ); ?>></td>*/ ?>
-        <td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]" value="inactive" <?php checked( 'inactive', $status ); ?>></td>
-</tr><?php
-endforeach;
-?></table><?php
+<?php if ( is_array( $all_plugins ) && count( $all_plugins ) ) : ?>
+	<table class="widefat plugins">
+		<thead>
+		<tr>
+			<th></th>
+			<th style="padding-left: 10px;"><?php _e( 'Plugin', 'plugin-conflicts' ); ?></th>
+			<th style="padding-left: 10px;"><?php _e( 'Active', 'plugin-conflicts' ); ?></th>
+			<?php /* <th style="padding-left: 10px;"><?php _e( 'switching', 'plugin-conflicts' ); ?></th>*/ ?>
+			<th style="padding-left: 10px;"><?php _e( 'Inactive', 'plugin-conflicts' ); ?></th>
+			<th style="padding-left: 10px;"><?php _e( 'Original Status', 'plugin-conflicts' ); ?></th>
+		</tr>
+		</thead>
+		<tbody>
+		<?php
+		foreach ( $all_plugins as $_plugin_path => $_plugin ) :
+			// load status
+			if ( isset( $plugins[ $_plugin_path ] ) ) {
+				$status = $plugins[ $_plugin_path ];
+			} else {
+				if ( is_plugin_active( $_plugin_path ) ) {
+					$status = 'active';
+				} else {
+					$status = 'inactive';
+				}
+			}
+			?>
+			<tr class="<?php echo $status; ?>">
+				<th class="check-column"></th>
+				<td><?php echo $_plugin['Name']; ?></td>
+				<td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]"
+				           value="active" <?php checked( 'active', $status ); ?>></td>
+				<?php /* <td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]" value="switching" <?php checked( 'switching', $status ); ?>></td>*/ ?>
+				<td><input type="radio" name="<?php echo PC_SLUG; ?>[plugins][<?php echo $_plugin_path; ?>]"
+				           value="inactive" <?php checked( 'inactive', $status ); ?>></td>
+				<td><?php echo is_plugin_active( $_plugin_path ) ? '<span style="color: #0073aa">active</span>' : '<span style="color: #a0a5aa">inactive</span>'; ?></td>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+		<tfoot>
+		<tr>
+			<th></th>
+			<th style="padding-left: 10px;"><?php _e( 'Plugin', 'plugin-conflicts' ); ?></th>
+			<th style="padding-left: 10px;"><?php _e( 'Active', 'plugin-conflicts' ); ?></th>
+			<?php /* <th style="padding-left: 10px;"><?php _e( 'switching', 'plugin-conflicts' ); ?></th>*/ ?>
+			<th style="padding-left: 10px;"><?php _e( 'Inactive', 'plugin-conflicts' ); ?></th>
+			<th style="padding-left: 10px;"><?php _e( 'Original Status', 'plugin-conflicts' ); ?></th>
+		</tr>
+		</tfoot>
+	</table>
+	<?php
 endif;


### PR DESCRIPTION
- `widefat` table for plugins, mimicking `plugins.php` table
- show "default" plugin active status alongside debug status
- better visual feedback whether debug is currently running or not
- no functional changes (although removed settings field and added settings sections)
